### PR TITLE
Bidder property for Auctions

### DIFF
--- a/src/structures/SkyBlock/Auctions/Bid.js
+++ b/src/structures/SkyBlock/Auctions/Bid.js
@@ -4,6 +4,7 @@ class Bid {
     this.profileId = data.profile_id || null;
     this.amount = data.amount || 0;
     this.timestamp = data.timestamp || null;
+    this.bidder = data.bidder || null;
   }
 }
 module.exports = Bid;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -304,6 +304,7 @@ class Bid {
     public profileId: string;
     public amount: number;
     public timestamp: number;
+    public bidder: string;
 }
 class Product {
     constructor(data: object);


### PR DESCRIPTION
Adds a bidder property (a string) to the Bid class (for skyblock auctions) as well as the corresponding type definitions