### PR TITLE
Fix for only 1 slayer type in API Data

### DIFF
--- a/src/utils/SkyblockUtils.js
+++ b/src/utils/SkyblockUtils.js
@@ -62,13 +62,15 @@ module.exports = {
   },
 
   getSlayerLevel (slayer) {
-    if (!slayer) return {
-      xp: 0,
-      tier1: 0,
-      tier2: 0,
-      tier3: 0,
-      tier4: 0,
-      level: 0
+    if (!slayer) {
+      return {
+        xp: 0,
+        tier1: 0,
+        tier2: 0,
+        tier3: 0,
+        tier4: 0,
+        level: 0
+      };
     }
 
     const { claimed_levels } = slayer;

--- a/src/utils/SkyblockUtils.js
+++ b/src/utils/SkyblockUtils.js
@@ -62,6 +62,15 @@ module.exports = {
   },
 
   getSlayerLevel (slayer) {
+    if (!slayer) return {
+      xp: 0,
+      tier1: 0,
+      tier2: 0,
+      tier3: 0,
+      tier4: 0,
+      level: 0
+    }
+
     const { claimed_levels } = slayer;
 
     let level = 0;


### PR DESCRIPTION
Added handling for the case that the slayer data from the hypixel API contains only 1 type of slayer and is missing the other two (and therefore can't destructure claimed_levels from slayer). (my bot encountered this issue on 1 single out of 100+ profiles)

- [ ] I've added new features (methods or parameters)
- [x] I've fixed a bug (*optional* you can mention a issue if there is one)
- [ ] I've corrected the spelling in README, documentation, etc.